### PR TITLE
feat: 데이터 증강 전처리

### DIFF
--- a/utils/aug_elder.py
+++ b/utils/aug_elder.py
@@ -137,7 +137,7 @@ def main(src_dir):
 
 if __name__ == '__main__':
     args = argparse.ArgumentParser(description = 'data preprocessing')
-    args.add_argument('-d', '--src_dir', default = '/data/ephemeral/home/level1-imageclassification-cv-14/data/train/debug_images_aug', type = str,
+    args.add_argument('-d', '--src_dir', default = './data/train/images_aug', type = str,
                       help='data folder path (default: ./data/train)')
     
     args = args.parse_args()

--- a/utils/aug_nomask.py
+++ b/utils/aug_nomask.py
@@ -6,9 +6,9 @@ from tqdm import tqdm
 from concurrent.futures import ProcessPoolExecutor
 
 class AugNoMask():
-    def __init__(self, suffix, src_dir, brightness, contrast):
+    def __init__(self, src_dir, dest_dir, brightness, contrast):
         self.src_dir = src_dir
-        self.dest_dir = src_dir + suffix
+        self.dest_dir = dest_dir
         self.n_cpu = multiprocessing.cpu_count()
 
         # params
@@ -99,17 +99,17 @@ class AugNoMask():
 
         return img
 
-def main(suffix, src_dir):
-    aug_data = AugNoMask(suffix, src_dir, brightness=64, contrast=64)
+def main(src_dir, dest_dir):
+    aug_data = AugNoMask(src_dir, dest_dir, brightness=64, contrast=64)
     aug_data.aug_data()
     print('Data augmentation completed.')
 
 if __name__ == '__main__':
     args = argparse.ArgumentParser(description='data preprocessing')
-    args.add_argument('-n', '--suffix', default='_aug', type=str,
+    args.add_argument('-s', '--src_dir', default='./data/train/images', type=str,
+                      help='src data folder path (default: ./data/train/images)')
+    args.add_argument('-d', '--dest_dir', default='./data/train/images_aug', type=str,
                       help='add folder name to aug ver data folder')
-    args.add_argument('-d', '--src_dir', default='./data/train/images', type=str,
-                      help='data folder path (default: ./data/train)')
-    
+
     args = args.parse_args()
-    main(args.suffix, args.src_dir)
+    main(args.src_dir, args.dest_dir)

--- a/utils/data_aug.py
+++ b/utils/data_aug.py
@@ -1,9 +1,9 @@
 from aug_nomask import *
 from aug_elder import *
 
-def main(suffix, src_data):
-    aug_nomask_data = AugNoMask(suffix, src_data, brightness=64, contrast=64)
-    aug_elder_data = AugElder(src_data+suffix)
+def main(src_dir, dest_dir):
+    aug_nomask_data = AugNoMask(src_dir, dest_dir, brightness=64, contrast=64)
+    aug_elder_data = AugElder(dest_dir)
 
     aug_nomask_data.aug_data()
     aug_elder_data.aug_data()
@@ -11,10 +11,10 @@ def main(suffix, src_data):
 
 if __name__ == '__main__':
     args = argparse.ArgumentParser(description='data preprocessing')
-    args.add_argument('-s', '--suffix', default='_aug', type=str,
-                      help='add folder name to aug ver data folder')
-    args.add_argument('-d', '--src_data', default="./data/train/images", type=str,
-                      help='data folder path')
-    
+    args.add_argument('-s', '--src_dir', default='/data/ephemeral/home/level1-imageclassification-cv-14/data/train/debug_images', type=str,
+                      help='src data folder path (default: ./data/train/images)')
+    args.add_argument('-d', '--dest_dir', default='/data/ephemeral/home/level1-imageclassification-cv-14/data/train/debug_images_aug', type=str,
+                      help='src data folder path (default: ./data/train/images_aug)')
+
     args = args.parse_args()
-    main(args.suffix, args.src_data)
+    main(args.src_dir, args.dest_dir)


### PR DESCRIPTION
## Overview
- 원본 데이터 비율, mask : no mask : incorrect mask = 5 : 1 : 1 
- 원본 데이터 비율, young : middle : old = 6 : 6 : 1 

## Change Log
- aug_nomask.py
- aug_elder.py
- data_aug.py

## To Reviewer
- blur(가우시안 노이즈), flip(좌우 반전), jitter(명암, 대조 설정), 세가지 방법을 이용하여 데이터를 증강하였습니다.

- 우선 aug_nomask 를 통해 mask : no mask : incorrect mask 비율을 1 : 1 : 1 로 맞춰주었습니다.
    - 명암과 대조를 (64, 64) 로 설정하였습니다.
    - blur 버전, flip 버전, jitter 버전, blur+flip 버전 이렇게 4개씩 늘려주었습니다.
    - utils > aug_nomask.py > aug_data 메소드에서 확인 가능합니다.
    - 추가된 파일은 기존 파일 이름 뒤에 "_{적용되는 function 이름들}" 이 suffix로 붙습니다.

- 이후 aug_elder를 통해 old 그룹의 개인 profile 폴더 들을 6배 증강시켜주었습니다.
    - 차례대로 [['blur','flip','jitter'], ['flip','jitter'], ['jitter'], ['blur', 'jitter'], ['flip', 'jitter']] 로 증강시켜주었습니다.
    - 참고로 이때의 jitter의 명암과 대조 값은 각각 (0, 13, 26, 39, 52) 중 랜덤한 조합으로 설정하였습니다.
    - utils > aug_elder.py > aug_elder_data 메소드에서 이를 확인 가능합니다.
    - 새롭게 만들어진 elder 그룹은 id 7000번대 부터 새롭게 폴더가 만들어지고, 데이터가 생성됩니다.
    - 추가된 파일은 기존 파일 이름 뒤에 "_{적용되는 function}_b{명암}_c{대조}"가 suffix로 붙습니다.

- 각각의 구현은 속도를 맞춰주기 위해 멀티 프로세싱으로 진행하였습니다.

- 실행 방법은 다음과 같습니다.
    - `python3 utils/data_aug.py --sufix _aug --data_dir ./data/train/images`
    - default가 각각 _aug 와 ./data/train/images로 설정 되어있습니다.

- 약 10분 가량 걸립니다.

![image](https://github.com/boostcampaitech6/level1-imageclassification-cv-14/assets/18082001/fd733598-8e56-491a-a30b-b13810e497ec)
- 증강된 데이터를 처리하기 위해 base_dataset.py에 하드코딩된 파일 라벨을 startwith로 수정해야할 필요가 있습니다.

- 예상보다 오래걸려서 미안합니다

## Issue Tags
- Closed: #39 